### PR TITLE
Using ilike instead of like for filter, per #12

### DIFF
--- a/src/client/utils/subscriptions/useDeploymentList.ts
+++ b/src/client/utils/subscriptions/useDeploymentList.ts
@@ -12,7 +12,7 @@ import {
 const LIST_DEPLOYMENTS = gql`
   subscription DeploymentList($filter: String) {
     deployments(
-      where: { display_name: { _like: $filter } }
+      where: { display_name: { _ilike: $filter } }
       order_by: { last_deployment_timestamp: desc }
     ) {
       id


### PR DESCRIPTION
**Problem:**
When using the filter in deploymentList case is sensitive leading to cases like where _api_ is found and not _API_ or _Api_.

**Fix:**
Changed gql statement to use _ilike and not _like for filtering displayName 

**Source**
https://hasura.io/blog/full-text-search-with-hasura-graphql-api-postgres/